### PR TITLE
Add basic React front page

### DIFF
--- a/FriendFinder/frontend/README.md
+++ b/FriendFinder/frontend/README.md
@@ -1,0 +1,11 @@
+# FriendFinder Frontend
+
+This is a simple React project built with [Vite](https://vitejs.dev/).
+
+## Available Scripts
+
+- `npm run dev` — start the development server
+- `npm run build` — build for production
+- `npm run preview` — preview the production build
+
+The homepage displays a heading, brief description, and a "Kom i gang" button.

--- a/FriendFinder/frontend/index.html
+++ b/FriendFinder/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FriendFinder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/FriendFinder/frontend/package.json
+++ b/FriendFinder/frontend/package.json
@@ -1,6 +1,18 @@
 {
   "name": "friendfinder-frontend",
-  "version": "0.1.0",
   "private": true,
-  "dependencies": {}
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
 }

--- a/FriendFinder/frontend/src/App.jsx
+++ b/FriendFinder/frontend/src/App.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div className="container">
+      <h1>FriendFinder</h1>
+      <p>Find and connect with new friends instantly.</p>
+      <button>Kom i gang</button>
+    </div>
+  );
+}
+
+export default App;

--- a/FriendFinder/frontend/src/index.css
+++ b/FriendFinder/frontend/src/index.css
@@ -1,0 +1,18 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.container {
+  text-align: center;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}

--- a/FriendFinder/frontend/src/main.jsx
+++ b/FriendFinder/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/FriendFinder/frontend/vite.config.js
+++ b/FriendFinder/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize Vite-based React app under `FriendFinder/frontend`
- show heading "FriendFinder", a short description, and a "Kom i gang" button

## Testing
- `npm run dev` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_685728d3a3ac832eb43cb33b28df7bed